### PR TITLE
Speedreader update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.1"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT"
 description = "(朽木) HTML/XML tree manipulation library"
-repository = "https://github.com/SimonSapin/kuchiki"
+repository = "https://github.com/kuchiki-rs/kuchiki"
 edition = "2018"
 
 [lib]
@@ -14,8 +14,9 @@ doctest = false
 [dependencies]
 cssparser = "0.27"
 matches = "0.1.4"
-html5ever = "0.25"
+html5ever = "0.26.0"
 selectors = "0.22"
+indexmap = "1.6.0"
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-Kuchiki (朽木)
-==============
+## Archived
 
-HTML/XML¹ tree manipulation library for Rust.
+This repository is archived to reflect its level of (in)activity and set maintenance expectations.
 
-[Documentation](https://docs.rs/kuchiki/)
+If some ideas or code in it are useful to you, feel free to use them in other repositories and crates
+in accordance with the license.
 
-See [users.rust-lang.org discussion](http://users.rust-lang.org/t/kuchiki-a-vaporware-html-xml-tree-manipulation-library/435).
+Note however that tree data structure design in Rust is full of trade-offs,
+maybe some approach other than `Rc`/`Weak` would work better for you.
+(For example [`Vec` + indices][1], if it’s acceptable
+not to recover memory for dropped nodes before the entire document is dropped.)
 
-¹ There is no support for XML syntax yet. The plan is to integrate with an existing parser.
+[1]: https://github.com/SimonSapin/victor/blob/fdb11f3e87f6d2d59170d10169fa6deb94e53b94/victor/src/dom/mod.rs#L19-L29

--- a/examples/find_matches.rs
+++ b/examples/find_matches.rs
@@ -4,7 +4,7 @@ use kuchiki::traits::*;
 
 fn main() {
     let html = r"
-        <DOCTYPE html>
+        <!DOCTYPE html>
         <html>
         <head></head>
         <body>

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,11 +1,11 @@
 use html5ever::{LocalName, Namespace, Prefix};
-use std::collections::btree_map::{BTreeMap, Entry};
+use indexmap::{map::Entry, IndexMap};
 
-/// Convenience wrapper around a btreemap that adds method for attributes in the null namespace.
+/// Convenience wrapper around a indexmap that adds method for attributes in the null namespace.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Attributes {
     /// A map of attributes whose name can have namespaces.
-    pub map: BTreeMap<ExpandedName, Attribute>,
+    pub map: IndexMap<ExpandedName, Attribute>,
 }
 
 /// <https://www.w3.org/TR/REC-xml-names/#dt-expname>
@@ -37,31 +37,31 @@ pub struct Attribute {
 }
 
 impl Attributes {
-    /// Like BTreeMap::contains
+    /// Like IndexMap::contains
     pub fn contains<A: Into<LocalName>>(&self, local_name: A) -> bool {
         self.map.contains_key(&ExpandedName::new(ns!(), local_name))
     }
 
-    /// Like BTreeMap::get
+    /// Like IndexMap::get
     pub fn get<A: Into<LocalName>>(&self, local_name: A) -> Option<&str> {
         self.map
             .get(&ExpandedName::new(ns!(), local_name))
             .map(|attr| &*attr.value)
     }
 
-    /// Like BTreeMap::get_mut
+    /// Like IndexMap::get_mut
     pub fn get_mut<A: Into<LocalName>>(&mut self, local_name: A) -> Option<&mut String> {
         self.map
             .get_mut(&ExpandedName::new(ns!(), local_name))
             .map(|attr| &mut attr.value)
     }
 
-    /// Like BTreeMap::entry
+    /// Like IndexMap::entry
     pub fn entry<A: Into<LocalName>>(&mut self, local_name: A) -> Entry<ExpandedName, Attribute> {
         self.map.entry(ExpandedName::new(ns!(), local_name))
     }
 
-    /// Like BTreeMap::insert
+    /// Like IndexMap::insert
     pub fn insert<A: Into<LocalName>>(
         &mut self,
         local_name: A,
@@ -76,7 +76,7 @@ impl Attributes {
         )
     }
 
-    /// Like BTreeMap::remove
+    /// Like IndexMap::remove
     pub fn remove<A: Into<LocalName>>(&mut self, local_name: A) -> Option<Attribute> {
         self.map.remove(&ExpandedName::new(ns!(), local_name))
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,7 @@ use html5ever::tree_builder::QuirksMode;
 use html5ever::QualName;
 use std::path::Path;
 
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 use crate::parser::{parse_html, parse_fragment};
 use crate::select::*;
@@ -86,7 +86,7 @@ fn parse_file() {
 
 #[test]
 fn serialize_and_read_file() {
-    let tempdir = TempDir::new("test_rm_tempdir").unwrap();
+    let tempdir = TempDir::new().unwrap();
     let mut path = tempdir.path().to_path_buf();
     path.push("temp.html");
 


### PR DESCRIPTION
Merge upstream changes into our speedreader branch.

Upstream has now archived their repo, so we're maintaining this on our own. This is mostly just to update deps.

No new test failures compared to the previous branch state, which doesn't pass everything.