### PR TITLE
Replace travis ci with github actions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,22 @@
+name: Security audit
+on:
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  pull_request:
+    branches:
+      main
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    - cron: '21 20 2 * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,34 @@
+name: Lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      main
+  schedule:
+    - cron: '28 20 2 * *'
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          components: clippy, rustfmt
+          toolchain: stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+    pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build
+      - name: Test
+        run: cargo test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: rust
-rust:
-  - nightly
-  - beta
-  - stable

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ to maintain the crate. However, the Brave project is still using
 a branch, and so will continue to maintain a fork.
 
 [Documentation](https://docs.rs/kuchiki)
+
+See the [Security Policy](SECURITY.md) for information on reporting vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+All versions including and above the current stable release version number.
+
+## Reporting a Vulnerability
+
+See https://hackerone.com/brave for details.

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -60,9 +60,7 @@ impl Serialize for NodeRef {
 
             (ChildrenOnly(_), _) => Ok(()),
 
-            (IncludeNode, NodeData::Doctype(doctype)) => {
-                serializer.write_doctype(&doctype.name)
-            }
+            (IncludeNode, NodeData::Doctype(doctype)) => serializer.write_doctype(&doctype.name),
             (IncludeNode, NodeData::Text(text)) => serializer.write_text(&text.borrow()),
             (IncludeNode, NodeData::Comment(text)) => serializer.write_comment(&text.borrow()),
             (IncludeNode, NodeData::ProcessingInstruction(contents)) => {


### PR DESCRIPTION
This just does a test build with the default cargo in the image, so there's minimal feedback on the state of the code and proposed changes.