### PR TITLE
Apply standard formatting

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -182,16 +182,24 @@ macro_rules! siblings_next {
     ($next: ident, $next_back: ident, $next_sibling: ident) => {
         fn $next(&mut self) -> Option<NodeRef> {
             #![allow(non_shorthand_field_patterns)]
-            self.0.take().map(|State { $next: next, $next_back: next_back }| {
-                if let Some(sibling) = next.$next_sibling() {
-                    if next != next_back {
-                        self.0 = Some(State { $next: sibling, $next_back: next_back })
+            self.0.take().map(
+                |State {
+                     $next: next,
+                     $next_back: next_back,
+                 }| {
+                    if let Some(sibling) = next.$next_sibling() {
+                        if next != next_back {
+                            self.0 = Some(State {
+                                $next: sibling,
+                                $next_back: next_back,
+                            })
+                        }
                     }
-                }
-                next
-            })
+                    next
+                },
+            )
         }
-    }
+    };
 }
 
 impl Iterator for Siblings {
@@ -231,11 +239,11 @@ macro_rules! descendants_next {
                 match (self.0).$next() {
                     Some(NodeEdge::Start(node)) => return Some(node),
                     Some(NodeEdge::End(_)) => {}
-                    None => return None
+                    None => return None,
                 }
             }
         }
-    }
+    };
 }
 
 impl Iterator for Descendants {
@@ -269,33 +277,40 @@ macro_rules! traverse_next {
     ($next: ident, $next_back: ident, $first_child: ident, $next_sibling: ident, $Start: ident, $End: ident) => {
         fn $next(&mut self) -> Option<NodeEdge<NodeRef>> {
             #![allow(non_shorthand_field_patterns)]
-            self.0.take().map(|State { $next: next, $next_back: next_back }| {
-                if next != next_back {
-                    self.0 = match next {
-                        NodeEdge::$Start(ref node) => {
-                            match node.$first_child() {
-                                Some(child) => {
-                                    Some(State { $next: NodeEdge::$Start(child), $next_back: next_back })
-                                }
-                                None => Some(State { $next: NodeEdge::$End(node.clone()), $next_back: next_back })
-                            }
-                        }
-                        NodeEdge::$End(ref node) => {
-                            match node.$next_sibling() {
-                                Some(sibling) => {
-                                    Some(State { $next: NodeEdge::$Start(sibling), $next_back: next_back })
-                                }
-                                None => node.parent().map(|parent| {
-                                    State { $next: NodeEdge::$End(parent), $next_back: next_back }
-                                })
-                            }
-                        }
-                    };
-                }
-                next
-            })
+            self.0.take().map(
+                |State {
+                     $next: next,
+                     $next_back: next_back,
+                 }| {
+                    if next != next_back {
+                        self.0 = match next {
+                            NodeEdge::$Start(ref node) => match node.$first_child() {
+                                Some(child) => Some(State {
+                                    $next: NodeEdge::$Start(child),
+                                    $next_back: next_back,
+                                }),
+                                None => Some(State {
+                                    $next: NodeEdge::$End(node.clone()),
+                                    $next_back: next_back,
+                                }),
+                            },
+                            NodeEdge::$End(ref node) => match node.$next_sibling() {
+                                Some(sibling) => Some(State {
+                                    $next: NodeEdge::$Start(sibling),
+                                    $next_back: next_back,
+                                }),
+                                None => node.parent().map(|parent| State {
+                                    $next: NodeEdge::$End(parent),
+                                    $next_back: next_back,
+                                }),
+                            },
+                        };
+                    }
+                    next
+                },
+            )
         }
-    }
+    };
 }
 
 impl Iterator for Traverse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod tree;
 
 pub use attributes::{Attribute, Attributes, ExpandedName};
 pub use node_data_ref::NodeDataRef;
-pub use parser::{parse_html, parse_html_with_options, parse_fragment, ParseOpts, Sink};
+pub use parser::{parse_fragment, parse_html, parse_html_with_options, ParseOpts, Sink};
 pub use select::{Selector, Selectors, Specificity};
 pub use tree::{Doctype, DocumentData, ElementData, Node, NodeData, NodeRef};
 
@@ -35,6 +35,6 @@ pub use tree::{Doctype, DocumentData, ElementData, Node, NodeData, NodeRef};
 /// use kuchiki::traits::*;
 /// ```
 pub mod traits {
-    pub use html5ever::tendril::TendrilSink;
     pub use crate::iter::{ElementIterator, NodeIterator};
+    pub use html5ever::tendril::TendrilSink;
 }

--- a/src/node_data_ref.rs
+++ b/src/node_data_ref.rs
@@ -1,7 +1,7 @@
+use crate::tree::{Doctype, DocumentData, ElementData, Node, NodeRef};
 use std::cell::RefCell;
 use std::fmt;
 use std::ops::Deref;
-use crate::tree::{Doctype, DocumentData, ElementData, Node, NodeRef};
 
 impl NodeRef {
     /// If this node is an element, return a strong reference to element-specific data.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -43,7 +43,11 @@ pub fn parse_fragment(ctx_name: QualName, ctx_attr: Vec<Attribute>) -> html5ever
 }
 
 /// Parse an HTML fragment with html5ever with custom configuration.
-pub fn parse_fragment_with_options(opts: ParseOpts, ctx_name: QualName, ctx_attr: Vec<Attribute>) -> html5ever::Parser<Sink> {
+pub fn parse_fragment_with_options(
+    opts: ParseOpts,
+    ctx_name: QualName,
+    ctx_attr: Vec<Attribute>,
+) -> html5ever::Parser<Sink> {
     let sink = Sink {
         document_node: NodeRef::new_document(),
         on_parse_error: opts.on_parse_error,

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,8 +1,9 @@
 use crate::attributes::ExpandedName;
-use cssparser::{self, CowRcStr, ParseError, SourceLocation, ToCss};
-use html5ever::{LocalName, Namespace};
 use crate::iter::{NodeIterator, Select};
 use crate::node_data_ref::NodeDataRef;
+use crate::tree::{ElementData, Node, NodeData, NodeRef};
+use cssparser::{self, CowRcStr, ParseError, SourceLocation, ToCss};
+use html5ever::{LocalName, Namespace};
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::context::QuirksMode;
 use selectors::parser::SelectorParseErrorKind;
@@ -11,7 +12,6 @@ use selectors::parser::{
 };
 use selectors::{self, matching, OpaqueElement};
 use std::fmt;
-use crate::tree::{ElementData, Node, NodeData, NodeRef};
 
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 ///
@@ -102,7 +102,10 @@ impl NonTSPseudoClass for PseudoClass {
     }
 
     fn is_user_action_state(&self) -> bool {
-        matches!(*self, PseudoClass::Active | PseudoClass::Hover | PseudoClass::Focus)
+        matches!(
+            *self,
+            PseudoClass::Active | PseudoClass::Hover | PseudoClass::Focus
+        )
     }
 
     fn has_zero_specificity(&self) -> bool {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use tempfile::TempDir;
 
-use crate::parser::{parse_html, parse_fragment};
+use crate::parser::{parse_fragment, parse_html};
 use crate::select::*;
 use crate::traits::*;
 
@@ -62,8 +62,14 @@ fn parse_and_serialize_fragment() {
 
     let ctx_name = QualName::new(None, ns!(html), local_name!("tbody"));
     let document = parse_fragment(ctx_name, vec![]).one(html);
-    assert_eq!(document.as_document().unwrap().quirks_mode(), QuirksMode::NoQuirks);
-    assert_eq!(document.to_string(), r"<html><tr><td>Test case</td></tr></html>");
+    assert_eq!(
+        document.as_document().unwrap().quirks_mode(),
+        QuirksMode::NoQuirks
+    );
+    assert_eq!(
+        document.to_string(),
+        r"<html><tr><td>Test case</td></tr></html>"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Result of running `cargo fmt --all` with rust 1.69.0. Should give us a stable base for running a fmt lint in continuous integration jobs going forward.