### PR TITLE
Set codeowners to the Brave rust review team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @brave/rust-deps-reviewers


### PR DESCRIPTION
Document a flexible group of contacts for maintaining the repo.