### PR TITLE
Fix the easy clippy warnings

### DIFF
--- a/src/node_data_ref.rs
+++ b/src/node_data_ref.rs
@@ -50,7 +50,7 @@ impl<T> NodeDataRef<T> {
         F: FnOnce(&Node) -> &T,
     {
         NodeDataRef {
-            _reference: f(&*rc),
+            _reference: f(&rc),
             _keep_alive: rc,
         }
     }
@@ -61,7 +61,7 @@ impl<T> NodeDataRef<T> {
     where
         F: FnOnce(&Node) -> Option<&T>,
     {
-        f(&*rc).map(|r| r as *const T).map(move |r| NodeDataRef {
+        f(&rc).map(|r| r as *const T).map(move |r| NodeDataRef {
             _reference: r,
             _keep_alive: rc,
         })

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -15,7 +15,7 @@ impl Serialize for NodeRef {
         traversal_scope: TraversalScope,
     ) -> Result<()> {
         match (traversal_scope, self.data()) {
-            (ref scope, &NodeData::Element(ref element)) => {
+            (ref scope, NodeData::Element(element)) => {
                 if *scope == IncludeNode {
                     let attrs = element.attributes.borrow();
 
@@ -60,12 +60,12 @@ impl Serialize for NodeRef {
 
             (ChildrenOnly(_), _) => Ok(()),
 
-            (IncludeNode, &NodeData::Doctype(ref doctype)) => {
+            (IncludeNode, NodeData::Doctype(doctype)) => {
                 serializer.write_doctype(&doctype.name)
             }
-            (IncludeNode, &NodeData::Text(ref text)) => serializer.write_text(&text.borrow()),
-            (IncludeNode, &NodeData::Comment(ref text)) => serializer.write_comment(&text.borrow()),
-            (IncludeNode, &NodeData::ProcessingInstruction(ref contents)) => {
+            (IncludeNode, NodeData::Text(text)) => serializer.write_text(&text.borrow()),
+            (IncludeNode, NodeData::Comment(text)) => serializer.write_comment(&text.borrow()),
+            (IncludeNode, NodeData::ProcessingInstruction(contents)) => {
                 let contents = contents.borrow();
                 serializer.write_processing_instruction(&contents.0, &contents.1)
             }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -99,7 +99,7 @@ impl Deref for NodeRef {
     type Target = Node;
     #[inline]
     fn deref(&self) -> &Node {
-        &*self.0
+        &self.0
     }
 }
 


### PR DESCRIPTION
This is about half the lints with `cargo +1.69.0 clippy`.