### PR TITLE
clippy: Use Iterator::find

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -399,12 +399,10 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<NodeDataRef<ElementData>> {
-        for element in self.iter.by_ref() {
-            if self.selectors.borrow().matches(&element) {
-                return Some(element);
-            }
-        }
-        None
+        let selectors = self.selectors.borrow();
+        self.iter
+            .by_ref()
+            .find(|element| selectors.matches(element))
     }
 }
 
@@ -415,12 +413,11 @@ where
 {
     #[inline]
     fn next_back(&mut self) -> Option<NodeDataRef<ElementData>> {
-        for element in self.iter.by_ref().rev() {
-            if self.selectors.borrow().matches(&element) {
-                return Some(element);
-            }
-        }
-        None
+        let selectors = self.selectors.borrow();
+        self.iter
+            .by_ref()
+            .rev()
+            .find(|element| selectors.matches(element))
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -75,7 +75,7 @@ fn parse_and_serialize_fragment() {
 #[test]
 fn parse_file() {
     let mut path = Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
-    path.push("test_data".to_string());
+    path.push("test_data");
     path.push("foo.html");
 
     let html = r"<!DOCTYPE html><html><head>


### PR DESCRIPTION
Shorten the `Interator` impls for `Select` by using the find method with a closure. Addresses a clippy lint.

The remaining lints after this are deferred to #9 since they require a semver bump.