### PR TITLE
Rename crate to kuchikiki

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,18 @@
 [package]
-name = "kuchiki"
+name = "kuchikiki"
 version = "0.8.1"
-authors = ["Simon Sapin <simon.sapin@exyr.org>"]
+authors = [
+  "Brave Authors",
+  "Ralph Giles <rgiles@brave.com>",
+  "Simon Sapin <simon.sapin@exyr.org>",
+]
 license = "MIT"
-description = "(朽木) HTML/XML tree manipulation library"
-repository = "https://github.com/kuchiki-rs/kuchiki"
+description = "(口利き) HTML tree manipulation library"
+repository = "https://github.com/brave/kuchikiki"
 edition = "2018"
 
 [lib]
-name = "kuchiki"
+name = "kuchikiki"
 doctest = false
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# Kuchiki (朽木)
+# Kuchikiki (口利き)
 
 HTML tree-manipulation library for Rust.
 
-Upstream has archived their repository, since they've been unable
-to maintain the crate. However, the Brave project is still using
-a branch, and so will continue to maintain a fork.
+[Documentation](https://docs.rs/kuchikiki)
 
-[Documentation](https://docs.rs/kuchiki)
+This is a fork of the Kuchiki (朽木) library, which in now unmaintained.
+The Brave project is still using a branch, and so will continue to
+support this repository. You can use this version by updating the name
+in your `Cargo.toml` (add an extra `ki`!) and then remap code references
+to the new name, e.g. with
+
+```rust
+use kuchikiki as kuchiki
+```
 
 See the [Security Policy](SECURITY.md) for information on reporting vulnerabilities.

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=https://docs.rs/kuchiki/">
-<link rel="canonical" href="https://docs.rs/kuchiki/">
-<a href="https://docs.rs/kuchiki/">Moved to docs.rs</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3 +1,0 @@
-<meta http-equiv="refresh" content="0; url=https://docs.rs/kuchiki/">
-<link rel="canonical" href="https://docs.rs/kuchiki/">
-<a href="https://docs.rs/kuchiki/">Moved to docs.rs</a>

--- a/examples/find_matches.rs
+++ b/examples/find_matches.rs
@@ -1,6 +1,4 @@
-extern crate kuchiki;
-
-use kuchiki::traits::*;
+use kuchikiki::traits::*;
 
 fn main() {
     let html = r"
@@ -16,7 +14,7 @@ fn main() {
     ";
     let css_selector = ".foo";
 
-    let document = kuchiki::parse_html().one(html);
+    let document = kuchikiki::parse_html().one(html);
 
     for css_match in document.select(css_selector).unwrap() {
         // css_match is a NodeDataRef, but most of the interesting methods are

--- a/examples/stack-overflow.rs
+++ b/examples/stack-overflow.rs
@@ -1,12 +1,10 @@
-extern crate kuchiki;
-
 fn main() {
     let mut depth = 2;
     // 20 M nodes is a few GB of memory.
     while depth <= 20_000_000 {
-        let mut node = kuchiki::NodeRef::new_text("");
+        let mut node = kuchikiki::NodeRef::new_text("");
         for _ in 0..depth {
-            let parent = kuchiki::NodeRef::new_text("");
+            let parent = kuchikiki::NodeRef::new_text("");
             parent.append(node);
             node = parent;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use tree::{Doctype, DocumentData, ElementData, Node, NodeData, NodeRef};
 /// It can be used with:
 ///
 /// ```rust
-/// use kuchiki::traits::*;
+/// use kuchikiki::traits::*;
 /// ```
 pub mod traits {
     pub use crate::iter::{ElementIterator, NodeIterator};


### PR DESCRIPTION
Upstream declined to transfer control of the original name, so rename our fork so we can publish separately.